### PR TITLE
Fix to check existence of "exclude" section

### DIFF
--- a/lib/jekyll/epub.rb
+++ b/lib/jekyll/epub.rb
@@ -108,7 +108,7 @@ module Jekyll
         next if url == self.config["epub"]["cover-image"]
         mime = MIME::Types.type_for( url ).to_s
         mime = "application/xhtml+xml" if mime == "text/html"     
-        next if self.config['exclude'].include?(File.basename( url ))
+        next if self.config['exclude'] and self.config['exclude'].include?(File.basename( url ))
         
         if mime == "" then
           $stderr.puts "** Ignore file #{url}, unknown mime type!"


### PR DESCRIPTION
It may cause building failure if no `exclude` section is set.
### jekyll_epub

```
$ bundle exec jekyll_epub
/Users/yuya/dev/php/php-the-right-way/vendor/bundle/ruby/1.9.1/gems/maruku-0.6.0/lib/maruku/input/parse_doc.rb:22:in `<top (required)>': iconv will be deprecated in the future, use String#encode instead.
** Configuration from /Users/yuya/dev/php/php-the-right-way/_epub.yml
/Users/yuya/dev/php/php-the-right-way/vendor/bundle/ruby/1.9.1/gems/jekyll-epub-0.0.3/lib/jekyll/epub.rb:111:in `block in package_epub': undefined method `include?' for nil:NilClass (NoMethodError)
        from /Users/yuya/dev/php/php-the-right-way/vendor/bundle/ruby/1.9.1/gems/jekyll-epub-0.0.3/lib/jekyll/epub.rb:106:in `each'
        from /Users/yuya/dev/php/php-the-right-way/vendor/bundle/ruby/1.9.1/gems/jekyll-epub-0.0.3/lib/jekyll/epub.rb:106:in `package_epub'
        from /Users/yuya/dev/php/php-the-right-way/vendor/bundle/ruby/1.9.1/gems/jekyll-epub-0.0.3/lib/jekyll/epub.rb:76:in `epub'
        from /Users/yuya/dev/php/php-the-right-way/vendor/bundle/ruby/1.9.1/gems/jekyll-epub-0.0.3/lib/jekyll/epub.rb:235:in `create'
        from /Users/yuya/dev/php/php-the-right-way/vendor/bundle/ruby/1.9.1/gems/jekyll-epub-0.0.3/bin/jekyll_epub:103:in `<top (required)>'
        from /Users/yuya/dev/php/php-the-right-way/vendor/bundle/ruby/1.9.1/bin/jekyll_epub:23:in `load'
        from /Users/yuya/dev/php/php-the-right-way/vendor/bundle/ruby/1.9.1/bin/jekyll_epub:23:in `<main>'
```
### rake epub

```
$ bundle exec rake epub --trace
/Users/yuya/dev/php/php-the-right-way/vendor/bundle/ruby/1.9.1/gems/maruku-0.6.0/lib/maruku/input/parse_doc.rb:22:in `<top (required)>': iconv will be deprecated in the future, use String#encode instead.
Configuration from /Users/yuya/dev/php/php-the-right-way/_config.yml
** Invoke epub (first_time)
** Execute epub
** Configuration from /Users/yuya/dev/php/php-the-right-way/_epub.yml
rake aborted!
undefined method `include?' for nil:NilClass
/Users/yuya/dev/php/php-the-right-way/vendor/bundle/ruby/1.9.1/gems/jekyll-epub-0.0.3/lib/jekyll/epub.rb:111:in `block in package_epub'
/Users/yuya/dev/php/php-the-right-way/vendor/bundle/ruby/1.9.1/gems/jekyll-epub-0.0.3/lib/jekyll/epub.rb:106:in `each'
/Users/yuya/dev/php/php-the-right-way/vendor/bundle/ruby/1.9.1/gems/jekyll-epub-0.0.3/lib/jekyll/epub.rb:106:in `package_epub'
/Users/yuya/dev/php/php-the-right-way/vendor/bundle/ruby/1.9.1/gems/jekyll-epub-0.0.3/lib/jekyll/epub.rb:76:in `epub'
/Users/yuya/dev/php/php-the-right-way/vendor/bundle/ruby/1.9.1/gems/jekyll-epub-0.0.3/lib/jekyll/epub.rb:235:in `create'
/Users/yuya/dev/php/php-the-right-way/vendor/bundle/ruby/1.9.1/gems/jekyll-epub-0.0.3/lib/jekyll/epub/tasks.rb:33:in `block in define_tasks'
/Users/yuya/.rbenv/versions/1.9.3-p194/lib/ruby/1.9.1/rake/task.rb:205:in `call'
/Users/yuya/.rbenv/versions/1.9.3-p194/lib/ruby/1.9.1/rake/task.rb:205:in `block in execute'
/Users/yuya/.rbenv/versions/1.9.3-p194/lib/ruby/1.9.1/rake/task.rb:200:in `each'
/Users/yuya/.rbenv/versions/1.9.3-p194/lib/ruby/1.9.1/rake/task.rb:200:in `execute'
/Users/yuya/.rbenv/versions/1.9.3-p194/lib/ruby/1.9.1/rake/task.rb:158:in `block in invoke_with_call_chain'
/Users/yuya/.rbenv/versions/1.9.3-p194/lib/ruby/1.9.1/monitor.rb:211:in `mon_synchronize'
/Users/yuya/.rbenv/versions/1.9.3-p194/lib/ruby/1.9.1/rake/task.rb:151:in `invoke_with_call_chain'
/Users/yuya/.rbenv/versions/1.9.3-p194/lib/ruby/1.9.1/rake/task.rb:144:in `invoke'
/Users/yuya/.rbenv/versions/1.9.3-p194/lib/ruby/1.9.1/rake/application.rb:116:in `invoke_task'
/Users/yuya/.rbenv/versions/1.9.3-p194/lib/ruby/1.9.1/rake/application.rb:94:in `block (2 levels) in top_level'
/Users/yuya/.rbenv/versions/1.9.3-p194/lib/ruby/1.9.1/rake/application.rb:94:in `each'
/Users/yuya/.rbenv/versions/1.9.3-p194/lib/ruby/1.9.1/rake/application.rb:94:in `block in top_level'
/Users/yuya/.rbenv/versions/1.9.3-p194/lib/ruby/1.9.1/rake/application.rb:133:in `standard_exception_handling'
/Users/yuya/.rbenv/versions/1.9.3-p194/lib/ruby/1.9.1/rake/application.rb:88:in `top_level'
/Users/yuya/.rbenv/versions/1.9.3-p194/lib/ruby/1.9.1/rake/application.rb:66:in `block in run'
/Users/yuya/.rbenv/versions/1.9.3-p194/lib/ruby/1.9.1/rake/application.rb:133:in `standard_exception_handling'
/Users/yuya/.rbenv/versions/1.9.3-p194/lib/ruby/1.9.1/rake/application.rb:63:in `run'
/Users/yuya/.rbenv/versions/1.9.3-p194/bin/rake:32:in `<main>'
Tasks: TOP => epub
```
